### PR TITLE
DRY up getStepTrends

### DIFF
--- a/src/ActivityRepository.js
+++ b/src/ActivityRepository.js
@@ -111,7 +111,8 @@ class ActivityRepository {
       if (positive && (day.numSteps > this.user[index - 1].numSteps) &&
         (this.user[index - 1].numSteps > this.user[index - 2].numSteps)) {
         acc.push(day.date);
-      } if (!positive && (day.numSteps < this.user[index - 1].numSteps) &&
+      } 
+      if (!positive && (day.numSteps < this.user[index - 1].numSteps) &&
         (this.user[index - 1].numSteps < this.user[index - 2].numSteps)) {
         acc.push(day.date);
       }

--- a/src/ActivityRepository.js
+++ b/src/ActivityRepository.js
@@ -103,25 +103,15 @@ class ActivityRepository {
     return this.user.slice(index - 6, index + 1);
   }
 
-  getPositiveStepTrends() {
+  getStepTrends(positive) {
     return this.user.reduce((acc, day, index) => {
       if (index < 2) {
         return acc;
       }
-      if ((day.numSteps > this.user[index - 1].numSteps) &&
+      if (positive && (day.numSteps > this.user[index - 1].numSteps) &&
         (this.user[index - 1].numSteps > this.user[index - 2].numSteps)) {
         acc.push(day.date);
-      }
-      return acc;
-    }, []);
-  }
-
-  getNegativeStepTrends() {
-    return this.user.reduce((acc, day, index) => {
-      if (index < 2) {
-        return acc;
-      }
-      if ((day.numSteps < this.user[index - 1].numSteps) &&
+      } if (!positive && (day.numSteps < this.user[index - 1].numSteps) &&
         (this.user[index - 1].numSteps < this.user[index - 2].numSteps)) {
         acc.push(day.date);
       }

--- a/src/index.js
+++ b/src/index.js
@@ -277,8 +277,8 @@ function displayFriendSteps(array) {
 }
 
 function displayTrends() {
-  let positiveTrend = activityRepository.getPositiveStepTrends().length;
-  let negativeTrend = activityRepository.getNegativeStepTrends().length;
+  let positiveTrend = activityRepository.getStepTrends(true).length;
+  let negativeTrend = activityRepository.getStepTrends(false).length;
   $(`<p>Since joining you've had:</p> <p><span>${positiveTrend}</span> positive trends</p>`).appendTo(stepTrends);
   $(`<p><span>${negativeTrend}</span> negative trends</p>`).appendTo(stepTrends);
 }

--- a/test/Activity-test.js
+++ b/test/Activity-test.js
@@ -141,9 +141,11 @@ describe('ActivityRepository', () => {
       ]);
   });
 
-  it('should return the positive or negative trend dates', () => {
+  it('should return the positive trend dates', () => {
     expect(activityRepository.getStepTrends(true)).to.deep.equal(['2019/08/20', '2019/08/23']);
-    expect(activityRepository.getStepTrends(false)).to.deep.equal([])
   });
 
+  it('should return the negative trend dates', () => {
+    expect(activityRepository.getStepTrends(false)).to.deep.equal([]);
+  });
 });

--- a/test/Activity-test.js
+++ b/test/Activity-test.js
@@ -141,11 +141,9 @@ describe('ActivityRepository', () => {
       ]);
   });
 
-  it('should return the positive trend dates', () => {
-    expect(activityRepository.getPositiveStepTrends()).to.deep.equal(['2019/08/20', '2019/08/23'])
+  it('should return the positive or negative trend dates', () => {
+    expect(activityRepository.getStepTrends(true)).to.deep.equal(['2019/08/20', '2019/08/23']);
+    expect(activityRepository.getStepTrends(false)).to.deep.equal([])
   });
 
-  it('should return the negative trend dates', () => {
-    expect(activityRepository.getNegativeStepTrends()).to.deep.equal([]);
-  });
 });


### PR DESCRIPTION
#### What's this PR do?

- This PR refactors two activityRepository functions into one that takes a boolean argument. The original functions were getPositiveStepTrends(), and getNegativeStepTrends(). Now they exist in getStepTrends(positive). When the function is invoked in index.js (lines 280 and 281) they are invoked with a boolean argument - true represents getting the positive trends, and false represents getting the negative trends. In the activityRepository function, I set some conditionals on which conditional to run wether positive is true or not, using if positive, or if !positive. I only have one commit for this PR but going forward, I probably would break this up into a few more, because this PR also adjusts the tests for this functionality and where the function is called in index.js, each of which should have been it's own commit. 
This PR fixes #7.

#### Where should the reviewer start?

- I'd mostly look at the differences in the activityRepository.js file, and then check out the changes in index.js, and activity-test.js as well

#### How should this be manually tested?

- Check the activity-tests themselves, and the way it displays on the dom.

#### Any background context you want to provide?

- One thing to note that might throw you off, is that in the activity-tests, the test for getting negative step trends is expecting an empty array. This is not a mistake. The sample data passed through the beforeEach does not include any negative step trends. I'd love some input on this - should we modify the sample data to include some negative step trends?

#### What are the relevant tickets?

- n/a

#### Screenshots (if appropriate)

- n/a

#### Questions:
- Is there a blog post? - no
- Does the knowledge base need an update? - no
- Does this add new dependencies which need to be added? -no

@brittanystoroz @khalidwilliams, I would like some input: should we modify the sample data in the beforeEach to include some negative step trends?