### PR TITLE
Refactor getAverages function in activityRepository

### DIFF
--- a/src/ActivityRepository.js
+++ b/src/ActivityRepository.js
@@ -80,7 +80,7 @@ class ActivityRepository {
     return Math.round(totalSteps / filteredDate.length);
   }
 
-  getAvergageMinutesActive(date) {
+  getAverageMinutesActive(date) {
     const filteredDate = this.getFilteredDate(date);
     const totalMinutes = filteredDate.reduce((total, log) => {
       total += log.minutesActive;

--- a/src/ActivityRepository.js
+++ b/src/ActivityRepository.js
@@ -76,8 +76,8 @@ class ActivityRepository {
     return parseFloat((miles * 1.609).toFixed(1));
   }
 
-  getDailyStats(date, detail) {
-    return this.getUserDate(date)[detail];
+  getDailyStats(date, property) {
+    return this.getUserDate(date)[property];
   }
 
   getWeeklyStats(date) {

--- a/src/ActivityRepository.js
+++ b/src/ActivityRepository.js
@@ -62,31 +62,13 @@ class ActivityRepository {
     };
   }
 
-  getAverageStairsDay(date) {
+  getAverages(date, property) {
     const filteredDate = this.getFilteredDate(date);
-    const totalStairs = filteredDate.reduce((total, log) => {
-      total += log.flightsOfStairs;
+    const total = filteredDate.reduce((total, log) => {
+      total += log[property];
       return total;
     }, 0);
-    return Math.round(totalStairs / filteredDate.length);
-  }
-
-  getAverageStepsDay(date) {
-    const filteredDate = this.getFilteredDate(date);
-    const totalSteps = filteredDate.reduce((total, log) => {
-      total += log.numSteps;
-      return total;
-    }, 0);
-    return Math.round(totalSteps / filteredDate.length);
-  }
-
-  getAverageMinutesActive(date) {
-    const filteredDate = this.getFilteredDate(date);
-    const totalMinutes = filteredDate.reduce((total, log) => {
-      total += log.minutesActive;
-      return total;
-    }, 0);
-    return Math.round(totalMinutes / filteredDate.length);
+    return Math.round(total / filteredDate.length);
   }
 
   getKilometersWalked(date, user) {

--- a/src/index.js
+++ b/src/index.js
@@ -202,9 +202,9 @@ function displayActivity() {
 }
 
 function displayAverageWeeklyActivity() {
-  const averageStairsDay = activityRepository.getAverageStairsDay(getCurrentDate());
-  const averageStepsDay = activityRepository.getAverageStepsDay(getCurrentDate());
-  const averageMinutesDay = activityRepository.getAverageMinutesActive(getCurrentDate());
+  const averageStairsDay = activityRepository.getAverages(getCurrentDate(), 'flightsOfStairs');
+  const averageStepsDay = activityRepository.getAverages(getCurrentDate(), 'numSteps');
+  const averageMinutesDay = activityRepository.getAverages(getCurrentDate(), 'minutesActive');
   const getDailyFlights = activityRepository.getDailyStats(getCurrentDate(), 'flightsOfStairs');
   const getDailySteps = activityRepository.getDailyStats(getCurrentDate(), 'numSteps');
   const getDailyMinutes = activityRepository.getDailyStats(getCurrentDate(), 'minutesActive');

--- a/src/index.js
+++ b/src/index.js
@@ -204,7 +204,7 @@ function displayActivity() {
 function displayAverageWeeklyActivity() {
   const averageStairsDay = activityRepository.getAverageStairsDay(getCurrentDate());
   const averageStepsDay = activityRepository.getAverageStepsDay(getCurrentDate());
-  const averageMinutesDay = activityRepository.getAvergageMinutesActive(getCurrentDate());
+  const averageMinutesDay = activityRepository.getAverageMinutesActive(getCurrentDate());
   const getDailyFlights = activityRepository.getDailyStats(getCurrentDate(), 'flightsOfStairs');
   const getDailySteps = activityRepository.getDailyStats(getCurrentDate(), 'numSteps');
   const getDailyMinutes = activityRepository.getDailyStats(getCurrentDate(), 'minutesActive');

--- a/test/Activity-test.js
+++ b/test/Activity-test.js
@@ -117,7 +117,7 @@ describe('ActivityRepository', () => {
   });
 
   it('should return the average number of minutes active for all users on a given date', () => {
-    expect(activityRepository.getAvergageMinutesActive('2019/08/25')).to.equal(226);
+    expect(activityRepository.getAverageMinutesActive('2019/08/25')).to.equal(226);
   });
 
   it('should return the number of kilometers a user walked in a given date', () => {

--- a/test/Activity-test.js
+++ b/test/Activity-test.js
@@ -109,15 +109,15 @@ describe('ActivityRepository', () => {
   });
 
   it('should return the average number of stairs climbed for all users on a given date', () => {
-    expect(activityRepository.getAverageStairsDay('2019/08/25')).to.equal(90);
+    expect(activityRepository.getAverages('2019/08/25', 'flightsOfStairs')).to.equal(90);
   });
 
   it('should return the average number of steps taken for all users on a given date', () => {
-    expect(activityRepository.getAverageStepsDay('2019/08/25')).to.equal(5540);
+    expect(activityRepository.getAverages('2019/08/25', 'numSteps')).to.equal(5540);
   });
 
   it('should return the average number of minutes active for all users on a given date', () => {
-    expect(activityRepository.getAverageMinutesActive('2019/08/25')).to.equal(226);
+    expect(activityRepository.getAverages('2019/08/25', 'minutesActive')).to.equal(226);
   });
 
   it('should return the number of kilometers a user walked in a given date', () => {


### PR DESCRIPTION
#### What's this PR do?

- This PR refactors three repetitive functions within the activity repo. All of them were getting averages for a different property, so I refactored them to take a property parameter, and then passed in the property as a string when I invoked the functions in the index.js file. 

#### Where should the reviewer start?

- activityProperty.js and look at line 65 - this is the single function, but it used to be three. 

#### How should this be manually tested?

- npm test will show you that all of the test have been adjusted to use this new function.

#### Any background context you want to provide?

- The codebase was already using this technique for the getDailyStats() function on line 79, so they must have run out of time to apply the same concept to the get averages function. I did adjust the getDailyStats parameter naming convention. It used to take a parameter of 'detail' but I renamed this to 'property' to be a little more descriptive, and to stay consistent with the new getAverages function. 

#### What are the relevant tickets?

- This PR fixes #5 and it also fixes #6 

#### Screenshots (if appropriate)

- n/a

#### Questions:

@benjamin-firth  @VeeAndrade - what do you think about the function on line 29 (getAverageActivity). It seems very similar, but it gets a whole weeks worth of data, instead of just average across all users for a single day. I've decided to leave it alone for now, but if you feel like we should mash these functions together, let me know!

- Is there a blog post? n/a
- Does the knowledge base need an update? n/a
- Does this add new dependencies which need to be added? n/a

@brittanystoroz @khalidwilliams