### PR TITLE
Add spies to getAverages method tests in activityRepo

### DIFF
--- a/test/Activity-test.js
+++ b/test/Activity-test.js
@@ -1,9 +1,10 @@
-const chai = require('chai');
-const expect = chai.expect;
+import chai, { expect } from 'chai';
+import spies from 'chai-spies';
 
 import User from '../src/User';
 import ActivityRepository from '../src/ActivityRepository';
 
+chai.use(spies);
 
 let activityRepository, activityData, user, sampleData;
 

--- a/test/Activity-test.js
+++ b/test/Activity-test.js
@@ -132,6 +132,13 @@ describe('ActivityRepository', () => {
   });
 
   it('should return the average number of minutes active for all users on a given date', () => {
+    chai.spy.on(activityRepository, 'getAllUserInfoByDate', () => {
+      return [
+        {"userID": 13, "date": "2019/08/25", "numSteps": 9352, "minutesActive": 567, "flightsOfStairs": 143},
+        { "userID": 5, "date": "2019/08/25", "numSteps": 6425, "minutesActive": 67, "flightsOfStairs": 42},
+        { "userID": 6, "date": "2019/08/25", "numSteps": 842, "minutesActive": 43, "flightsOfStairs": 86 } 
+      ];
+    })
     expect(activityRepository.getAverages('2019/08/25', 'minutesActive')).to.equal(226);
   });
 

--- a/test/Activity-test.js
+++ b/test/Activity-test.js
@@ -121,6 +121,13 @@ describe('ActivityRepository', () => {
   });
 
   it('should return the average number of steps taken for all users on a given date', () => {
+    chai.spy.on(activityRepository, 'getAllUserInfoByDate', () => {
+      return [
+        {"userID": 13, "date": "2019/08/25", "numSteps": 9352, "minutesActive": 567, "flightsOfStairs": 143},
+        { "userID": 5, "date": "2019/08/25", "numSteps": 6425, "minutesActive": 67, "flightsOfStairs": 42},
+        { "userID": 6, "date": "2019/08/25", "numSteps": 842, "minutesActive": 43, "flightsOfStairs": 86 } 
+      ];
+    })
     expect(activityRepository.getAverages('2019/08/25', 'numSteps')).to.equal(5540);
   });
 

--- a/test/Activity-test.js
+++ b/test/Activity-test.js
@@ -110,6 +110,13 @@ describe('ActivityRepository', () => {
   });
 
   it('should return the average number of stairs climbed for all users on a given date', () => {
+    chai.spy.on(activityRepository, 'getAllUserInfoByDate', () => {
+      return [
+        {"userID": 13, "date": "2019/08/25", "numSteps": 9352, "minutesActive": 567, "flightsOfStairs": 143},
+        { "userID": 5, "date": "2019/08/25", "numSteps": 6425, "minutesActive": 67, "flightsOfStairs": 42},
+        { "userID": 6, "date": "2019/08/25", "numSteps": 842, "minutesActive": 43, "flightsOfStairs": 86 } 
+      ];
+    })
     expect(activityRepository.getAverages('2019/08/25', 'flightsOfStairs')).to.equal(90);
   });
 


### PR DESCRIPTION
#### What's this PR do?
 - This PR add spies to the all of the tests that rely on the UtilityRepository's getAllUserInfoByDate method, to ensure that it is being invoked.
#### Where should the reviewer start?
 - Activity-test.js 
#### How should this be manually tested?
 - run npm test.

@brittanystoroz @khalidwilliams